### PR TITLE
feat: build eval runner CLI

### DIFF
--- a/.claude/skills/issue-review/SKILL.md
+++ b/.claude/skills/issue-review/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: issue-review
+description: Review a GitHub issue by number. Fetches the issue, analyzes scope, maps dependencies to current codebase state, and produces an implementation plan.
+user-invocable: true
+---
+
+# Issue Review: #$ARGUMENTS
+
+Review GitHub issue #$ARGUMENTS and produce a structured implementation plan.
+
+## Step 1: Fetch the Issue
+
+```bash
+gh issue view $ARGUMENTS
+```
+
+Capture: title, labels, body (scope, acceptance criteria, dependencies, out of scope).
+
+## Step 2: Check Dependencies
+
+For each issue listed under **Dependencies**:
+
+```bash
+gh issue view <dep-number>
+```
+
+Determine if each dependency is closed (merged) or still open. Flag any open blockers.
+
+## Step 3: Assess Current Codebase
+
+Read the relevant source files to understand what exists today. Map acceptance criteria to what's already built vs what needs to be created.
+
+## Step 4: Produce the Review
+
+Output a structured review with these sections:
+
+### Status
+
+- Issue state (open/closed) and labels
+- Dependency status: which are merged, which are blocking
+
+### Scope Summary
+
+- One-paragraph summary of what this issue delivers
+- Key behaviors and constraints
+
+### Acceptance Criteria Breakdown
+
+For each acceptance criterion:
+
+- **Criterion**: the requirement
+- **Status**: not started / partially done / done
+- **Approach**: how to implement it (files to create/modify, key decisions)
+- **Complexity**: low / medium / high
+
+### Open Questions
+
+Anything ambiguous, underspecified, or worth discussing before implementation.
+
+### Suggested Implementation Order
+
+Numbered list of steps, ordered by dependency chain and complexity. Group into logical commits.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/node": "^25.6.0",
         "eslint": "^10.2.0",
         "eslint-config-prettier": "^10.1.8",
         "prettier": "^3.8.1",
@@ -598,6 +599,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.1",
@@ -2228,6 +2239,13 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/node": "^25.6.0",
     "eslint": "^10.2.0",
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.8.1",

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { parseCliArgs } from "./args.js";
+
+describe("parseCliArgs", () => {
+  it("returns defaults for bare 'eval' command", () => {
+    const args = parseCliArgs(["eval"]);
+    expect(args).toEqual({
+      command: "eval",
+      config: "./assay.yaml",
+      tag: undefined,
+      repeat: 1,
+      format: "json",
+      concurrency: 1,
+      dryRun: false,
+      failFast: false,
+      timeout: 30000,
+    });
+  });
+
+  it("returns help when no command is provided", () => {
+    const args = parseCliArgs([]);
+    expect(args.command).toBe("help");
+  });
+
+  it("returns help with --help flag", () => {
+    const args = parseCliArgs(["--help"]);
+    expect(args.command).toBe("help");
+  });
+
+  it("returns help with -h flag", () => {
+    const args = parseCliArgs(["-h"]);
+    expect(args.command).toBe("help");
+  });
+
+  it("parses --config", () => {
+    const args = parseCliArgs(["eval", "--config", "./my-agent.yaml"]);
+    expect(args.config).toBe("./my-agent.yaml");
+  });
+
+  it("parses --tag", () => {
+    const args = parseCliArgs(["eval", "--tag", "security"]);
+    expect(args.tag).toBe("security");
+  });
+
+  it("parses --repeat", () => {
+    const args = parseCliArgs(["eval", "--repeat", "5"]);
+    expect(args.repeat).toBe(5);
+  });
+
+  it("parses --format json", () => {
+    const args = parseCliArgs(["eval", "--format", "json"]);
+    expect(args.format).toBe("json");
+  });
+
+  it("parses --format markdown", () => {
+    const args = parseCliArgs(["eval", "--format", "markdown"]);
+    expect(args.format).toBe("markdown");
+  });
+
+  it("parses --concurrency", () => {
+    const args = parseCliArgs(["eval", "--concurrency", "8"]);
+    expect(args.concurrency).toBe(8);
+  });
+
+  it("parses --dry-run", () => {
+    const args = parseCliArgs(["eval", "--dry-run"]);
+    expect(args.dryRun).toBe(true);
+  });
+
+  it("parses --fail-fast", () => {
+    const args = parseCliArgs(["eval", "--fail-fast"]);
+    expect(args.failFast).toBe(true);
+  });
+
+  it("parses --timeout", () => {
+    const args = parseCliArgs(["eval", "--timeout", "5000"]);
+    expect(args.timeout).toBe(5000);
+  });
+
+  it("throws on invalid --format value", () => {
+    expect(() => parseCliArgs(["eval", "--format", "xml"])).toThrow('Invalid --format value "xml"');
+  });
+
+  it("throws on --repeat 0", () => {
+    expect(() => parseCliArgs(["eval", "--repeat", "0"])).toThrow("--repeat must be a positive");
+  });
+
+  it("throws on zero --concurrency", () => {
+    expect(() => parseCliArgs(["eval", "--concurrency", "0"])).toThrow(
+      "--concurrency must be a positive",
+    );
+  });
+
+  it("throws when --concurrency exceeds max", () => {
+    expect(() => parseCliArgs(["eval", "--concurrency", "100"])).toThrow(
+      "--concurrency must be at most 64",
+    );
+  });
+
+  it("throws when --repeat exceeds max", () => {
+    expect(() => parseCliArgs(["eval", "--repeat", "1001"])).toThrow(
+      "--repeat must be at most 1000",
+    );
+  });
+
+  it("throws on non-integer --timeout", () => {
+    expect(() => parseCliArgs(["eval", "--timeout", "abc"])).toThrow(
+      "--timeout must be a positive",
+    );
+  });
+
+  it("throws on unknown flag", () => {
+    expect(() => parseCliArgs(["eval", "--unknown"])).toThrow();
+  });
+
+  it("parses multiple flags together", () => {
+    const args = parseCliArgs([
+      "eval",
+      "--config",
+      "./agent.yaml",
+      "--tag",
+      "security",
+      "--repeat",
+      "3",
+      "--format",
+      "markdown",
+      "--concurrency",
+      "4",
+      "--dry-run",
+      "--fail-fast",
+      "--timeout",
+      "10000",
+    ]);
+    expect(args).toEqual({
+      command: "eval",
+      config: "./agent.yaml",
+      tag: "security",
+      repeat: 3,
+      format: "markdown",
+      concurrency: 4,
+      dryRun: true,
+      failFast: true,
+      timeout: 10000,
+    });
+  });
+});

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,126 @@
+import { parseArgs } from "node:util";
+
+export interface CliArgs {
+  command: "eval" | "help";
+  config: string;
+  tag: string | undefined;
+  repeat: number;
+  format: "json" | "markdown";
+  concurrency: number;
+  dryRun: boolean;
+  failFast: boolean;
+  timeout: number;
+}
+
+/**
+ * Parse CLI arguments using Node's built-in util.parseArgs.
+ *
+ * @param argv - process.argv.slice(2) — positionals + flags only, no node/script path.
+ * @throws {Error} on invalid flag values or unknown flags.
+ */
+export function parseCliArgs(argv: string[]): CliArgs {
+  const { values, positionals } = parseArgs({
+    args: argv,
+    options: {
+      config: { type: "string", default: "./assay.yaml" },
+      tag: { type: "string" },
+      repeat: { type: "string", default: "1" },
+      format: { type: "string", default: "json" },
+      concurrency: { type: "string", default: "1" },
+      "dry-run": { type: "boolean", default: false },
+      "fail-fast": { type: "boolean", default: false },
+      timeout: { type: "string", default: "30000" },
+      help: { type: "boolean", short: "h", default: false },
+    },
+    allowPositionals: true,
+    strict: true,
+  });
+
+  if (values.help === true) {
+    return makeHelpArgs();
+  }
+
+  const command = positionals[0];
+  if (command === undefined || command !== "eval") {
+    return makeHelpArgs();
+  }
+
+  const repeat = parseBoundedInt(values.repeat as string, "repeat", 1000); // safe: has default
+  const concurrency = parseBoundedInt(values.concurrency as string, "concurrency", 64); // safe: has default
+  const timeout = parsePositiveInt(values.timeout as string, "timeout"); // safe: has default
+
+  const format = values.format as string;
+  if (format !== "json" && format !== "markdown") {
+    throw new Error(`Invalid --format value "${format}". Must be "json" or "markdown".`);
+  }
+
+  return {
+    command: "eval",
+    config: values.config as string,
+    tag: values.tag as string | undefined,
+    repeat,
+    format,
+    concurrency,
+    dryRun: values["dry-run"] as boolean,
+    failFast: values["fail-fast"] as boolean,
+    timeout,
+  };
+}
+
+function makeHelpArgs(): CliArgs {
+  return {
+    command: "help",
+    config: "./assay.yaml",
+    tag: undefined,
+    repeat: 1,
+    format: "json",
+    concurrency: 1,
+    dryRun: false,
+    failFast: false,
+    timeout: 30000,
+  };
+}
+
+function parsePositiveInt(value: string, name: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(`--${name} must be a positive integer, got "${value}".`);
+  }
+  return n;
+}
+
+function parseBoundedInt(value: string, name: string, max: number): number {
+  const n = parsePositiveInt(value, name);
+  if (n > max) {
+    throw new Error(`--${name} must be at most ${String(max)}, got "${value}".`);
+  }
+  return n;
+}
+
+export function printUsage(): void {
+  const usage = `
+Usage: assay <command> [options]
+
+Commands:
+  eval    Run eval cases against an agent and produce a proof result
+
+Options:
+  --config <path>       Path to agent config file (default: ./assay.yaml)
+  --tag <tag>           Run only cases matching this tag
+  --repeat <n>          Run each case N times for variance measurement (default: 1)
+  --format <fmt>        Output format: json | markdown (default: json)
+  --concurrency <n>     Max parallel case invocations (default: 1, sequential)
+  --dry-run             Validate config and list cases without executing
+  --fail-fast           Stop on first case failure
+  --timeout <ms>        Per-case timeout in milliseconds (default: 30000)
+  -h, --help            Show this help message
+
+Examples:
+  assay eval
+  assay eval --config ./my-agent.yaml --tag security
+  assay eval --repeat 3 --format markdown
+  assay eval --concurrency 4 --fail-fast
+`.trimStart();
+
+  process.stdout.write(usage);
+}

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1,0 +1,91 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { stringify } from "yaml";
+
+const CLI_PATH = resolve("dist/cli/index.js");
+
+// Create a self-contained test fixture with config + eval suite
+let fixtureDir: string;
+let fixtureConfig: string;
+
+beforeAll(async () => {
+  fixtureDir = await mkdtemp(join(tmpdir(), "assay-cli-test-"));
+  const evalDir = join(fixtureDir, "evals", "test-agent");
+  await mkdir(evalDir, { recursive: true });
+
+  fixtureConfig = join(fixtureDir, "assay.yaml");
+  await writeFile(
+    fixtureConfig,
+    stringify({
+      schema_version: "1",
+      agent: { id: "test-agent", name: "Test", description: "Test", version: "1.0.0" },
+      invoke: { type: "command", command: "echo hello" },
+      known_gaps: ["none"],
+      eval_suite: "evals/test-agent",
+    }),
+  );
+  await writeFile(
+    join(evalDir, "suite.yaml"),
+    stringify([
+      {
+        id: "case-1",
+        input: "test",
+        grading: [{ type: "deterministic", check: "contains", values: ["hello"] }],
+      },
+    ]),
+  );
+});
+
+afterAll(async () => {
+  await rm(fixtureDir, { recursive: true, force: true });
+});
+
+function runCli(
+  args: string[],
+  cwd?: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve) => {
+    execFile("node", [CLI_PATH, ...args], { cwd }, (error, stdout, stderr) => {
+      resolve({
+        stdout: stdout.toString(),
+        stderr: stderr.toString(),
+        exitCode: error?.code !== undefined ? (error.code as number) : 0,
+      });
+    });
+  });
+}
+
+describe("CLI integration", () => {
+  it("prints usage with --help", async () => {
+    const { stdout } = await runCli(["--help"]);
+    expect(stdout).toContain("Usage: assay");
+    expect(stdout).toContain("--config");
+    expect(stdout).toContain("--format");
+  });
+
+  it("prints usage with no command", async () => {
+    const { stdout } = await runCli([]);
+    expect(stdout).toContain("Usage: assay");
+  });
+
+  it("runs dry run with fixture config", async () => {
+    const { stdout, stderr } = await runCli(["eval", "--config", fixtureConfig, "--dry-run"]);
+    expect(stderr).toContain("Dry run:");
+    expect(stdout).toContain('"cases_run": 0');
+  });
+
+  it("exits with error for missing config file", async () => {
+    const { stderr, exitCode } = await runCli(["eval", "--config", "./nonexistent.yaml"]);
+    expect(stderr).toContain("Config file not found");
+    expect(exitCode).toBe(1);
+  });
+
+  it("exits with error for invalid config", async () => {
+    const { stderr, exitCode } = await runCli(["eval", "--config", "./package.json"]);
+    expect(stderr).toContain("Invalid agent config");
+    expect(exitCode).toBe(1);
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,3 +1,74 @@
 #!/usr/bin/env node
 
-// CLI entry point — populated in issue #3
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { parseCliArgs, printUsage } from "./args.js";
+import { validateAgentProof } from "../schema/validation.js";
+import { runEvalSuite } from "../runner/index.js";
+import { formatReport } from "../report/index.js";
+
+async function main(): Promise<void> {
+  let args;
+  try {
+    args = parseCliArgs(process.argv.slice(2));
+  } catch (err: unknown) {
+    process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n\n`);
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  if (args.command === "help") {
+    printUsage();
+    return;
+  }
+
+  // Load and validate agent config
+  const configPath = resolve(args.config);
+  let configYaml: string;
+  try {
+    configYaml = await readFile(configPath, "utf-8");
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+      process.stderr.write(`Error: Config file not found: ${configPath}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    throw err;
+  }
+
+  const configResult = validateAgentProof(configYaml);
+  if (!configResult.success) {
+    process.stderr.write(`Error: Invalid agent config at ${configPath}\n`);
+    for (const issue of configResult.error.issues) {
+      process.stderr.write(`  - ${issue.path.join(".")}: ${issue.message}\n`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = await runEvalSuite({
+    config: configResult.data,
+    configDir: dirname(configPath),
+    tag: args.tag,
+    repeat: args.repeat,
+    concurrency: args.concurrency,
+    failFast: args.failFast,
+    timeout: args.timeout,
+    dryRun: args.dryRun,
+  });
+
+  const output = formatReport(result.proofResult, args.format);
+  process.stdout.write(output + "\n");
+
+  if (args.dryRun) {
+    process.exitCode = 0;
+  } else {
+    process.exitCode = result.proofResult.cases_failed > 0 ? 1 : 0;
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exitCode = 1;
+});

--- a/src/confidence/index.ts
+++ b/src/confidence/index.ts
@@ -1,1 +1,41 @@
-// Confidence scoring and maturity tiers — populated in issue #7
+import type { MaturityTier } from "../schema/types.js";
+
+export interface ConfidenceResult {
+  score: number;
+  maturity: MaturityTier;
+  case_count: number;
+  variance: number;
+}
+
+/**
+ * Compute confidence from per-case pass rates.
+ *
+ * Score is the mean of all pass rates. Variance is the statistical variance
+ * across pass rates (measures consistency — low variance = reliable agent).
+ *
+ * STUB: maturity is always "unestablished" until issue #7 implements tier logic.
+ *
+ * @param casePassRates - Array of pass rates per case (0.0–1.0). E.g. a case
+ *   that passed 2/3 repeats has a rate of ~0.667.
+ */
+export function computeConfidence(casePassRates: number[]): ConfidenceResult {
+  const caseCount = casePassRates.length;
+
+  if (caseCount === 0) {
+    return { score: 0, maturity: "unestablished", case_count: 0, variance: 0 };
+  }
+
+  const sum = casePassRates.reduce((acc, r) => acc + r, 0);
+  const score = sum / caseCount;
+
+  // Population variance: mean of squared deviations from the mean
+  const squaredDiffs = casePassRates.reduce((acc, r) => acc + (r - score) ** 2, 0);
+  const variance = squaredDiffs / caseCount;
+
+  return {
+    score,
+    maturity: "unestablished",
+    case_count: caseCount,
+    variance,
+  };
+}

--- a/src/grading/index.ts
+++ b/src/grading/index.ts
@@ -1,1 +1,34 @@
-// Three-layer grading pipeline — populated in issues #4-6
+import type { EvalCase, GradingLayer } from "../schema/types.js";
+
+/** Result of a single grading layer evaluation. */
+export interface GradingLayerResult {
+  layer_type: GradingLayer["type"];
+  check: string;
+  passed: boolean;
+  /** Normalized score from 0.0 (complete fail) to 1.0 (complete pass). */
+  score: number;
+  details: string;
+  /** Token usage for LLM-judge calls. Populated by issues #4-6. */
+  token_usage?: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+}
+
+/**
+ * Run all grading layers for a single case against the agent output.
+ *
+ * STUB: returns all-pass until issues #4-6 implement real grading.
+ */
+export function gradeCase(evalCase: EvalCase, _agentOutput: string): GradingLayerResult[] {
+  return evalCase.grading.map((layer): GradingLayerResult => {
+    const check = layer.type === "llm-judge" ? "llm-judge" : layer.check;
+    return {
+      layer_type: layer.type,
+      check,
+      passed: true,
+      score: 1.0,
+      details: "STUB: grading not yet implemented",
+    };
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,14 @@ export {
   validateEvalSuite,
   validateProofResult,
 } from "./schema/index.js";
+
+export { invokeAgent, type InvokeResult } from "./invoke/index.js";
+export {
+  runEvalSuite,
+  type RunOptions,
+  type RunResult,
+  type CaseTimingDetail,
+} from "./runner/index.js";
+export { gradeCase, type GradingLayerResult } from "./grading/index.js";
+export { computeConfidence, type ConfidenceResult } from "./confidence/index.js";
+export { formatReport } from "./report/index.js";

--- a/src/invoke/index.test.ts
+++ b/src/invoke/index.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { invokeAgent } from "./index.js";
+import type { Invoke } from "../schema/types.js";
+
+describe("invokeAgent — command", () => {
+  const echoInvoke: Invoke = { type: "command", command: "echo hello" };
+
+  it("captures stdout from a simple command", async () => {
+    const result = await invokeAgent(echoInvoke, "", 5000);
+    expect(result.output.trim()).toBe("hello");
+    expect(result.exit_code).toBe(0);
+    expect(result.status_code).toBeNull();
+    expect(result.timed_out).toBe(false);
+    expect(result.truncated).toBe(false);
+    expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("pipes stdin to the command", async () => {
+    const catInvoke: Invoke = { type: "command", command: "cat" };
+    const result = await invokeAgent(catInvoke, "test input", 5000);
+    expect(result.output).toBe("test input");
+    expect(result.exit_code).toBe(0);
+  });
+
+  it("times out and kills long-running commands", async () => {
+    const sleepInvoke: Invoke = { type: "command", command: "sleep 60" };
+    const result = await invokeAgent(sleepInvoke, "", 100);
+    expect(result.timed_out).toBe(true);
+    expect(result.duration_ms).toBeLessThan(5000);
+  });
+
+  it("captures output from commands with non-zero exit code", async () => {
+    const result = await invokeAgent(
+      { type: "command", command: "node -e process.exit(42)" },
+      "",
+      5000,
+    );
+    expect(result.exit_code).toBe(42);
+    expect(result.timed_out).toBe(false);
+  });
+
+  it("returns immediately when abort signal is already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const result = await invokeAgent(echoInvoke, "", 5000, ac.signal);
+    expect(result.output).toBe("");
+    expect(result.duration_ms).toBe(0);
+  });
+
+  it("aborts in-flight command when external signal fires", async () => {
+    const ac = new AbortController();
+    const sleepInvoke: Invoke = { type: "command", command: "sleep 60" };
+    const promise = invokeAgent(sleepInvoke, "", 30000, ac.signal);
+
+    // Abort after a short delay
+    setTimeout(() => ac.abort(), 50);
+
+    const result = await promise;
+    expect(result.duration_ms).toBeLessThan(5000);
+  });
+});
+
+describe("invokeAgent — http", () => {
+  const httpInvoke: Invoke = { type: "http", http: "https://example.com/agent" };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends POST with JSON body and returns response text", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response("agent response", { status: 200 }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await invokeAgent(httpInvoke, "test input", 5000);
+    expect(result.output).toBe("agent response");
+    expect(result.exit_code).toBeNull();
+    expect(result.status_code).toBe(200);
+    expect(result.timed_out).toBe(false);
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://example.com/agent");
+    expect(opts.method).toBe("POST");
+    expect(opts.headers).toEqual({ "Content-Type": "application/json" });
+    expect(opts.body).toBe(JSON.stringify({ input: "test input" }));
+  });
+
+  it("handles HTTP timeout", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockRejectedValue(new DOMException("The operation was aborted.", "AbortError"));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await invokeAgent(httpInvoke, "test", 100);
+    expect(result.timed_out).toBe(true);
+    expect(result.output).toBe("");
+  });
+
+  it("captures non-2xx responses as output", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(new Response("Internal Server Error", { status: 500 }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await invokeAgent(httpInvoke, "test", 5000);
+    expect(result.output).toBe("Internal Server Error");
+    expect(result.timed_out).toBe(false);
+  });
+
+  it("returns immediately when abort signal is already aborted", async () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    const ac = new AbortController();
+    ac.abort();
+    const result = await invokeAgent(httpInvoke, "test", 5000, ac.signal);
+    expect(result.output).toBe("");
+    expect(result.duration_ms).toBe(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/invoke/index.ts
+++ b/src/invoke/index.ts
@@ -1,0 +1,248 @@
+import { spawn } from "node:child_process";
+import type { Invoke } from "../schema/types.js";
+
+/** Maximum output size in characters — matches MAX_OUTPUT_LENGTH in schema. */
+const MAX_OUTPUT_LENGTH = 65536;
+
+export interface InvokeResult {
+  output: string;
+  duration_ms: number;
+  /** Process exit code. null for http invocations or if the process was killed. */
+  exit_code: number | null;
+  /** HTTP status code. null for command invocations. */
+  status_code: number | null;
+  timed_out: boolean;
+  /** True if the output was truncated to MAX_OUTPUT_LENGTH. */
+  truncated: boolean;
+}
+
+/**
+ * Invoke the agent with the given input string, respecting the timeout.
+ *
+ * For command: spawns subprocess, passes input via stdin, captures stdout.
+ * For http: POSTs input as JSON body, reads response body.
+ */
+export async function invokeAgent(
+  invoke: Invoke,
+  input: string,
+  timeoutMs: number,
+  abortSignal?: AbortSignal,
+): Promise<InvokeResult> {
+  if (invoke.type === "command") {
+    return invokeCommand(invoke.command, input, timeoutMs, abortSignal);
+  }
+  return invokeHttp(invoke.http, input, timeoutMs, abortSignal);
+}
+
+function invokeCommand(
+  command: string,
+  input: string,
+  timeoutMs: number,
+  externalSignal?: AbortSignal,
+): Promise<InvokeResult> {
+  return new Promise((resolve, reject) => {
+    const start = performance.now();
+
+    // Naive space-split for v1. Quoted arguments are not supported.
+    const parts = command.split(/\s+/).filter((s) => s.length > 0);
+    const cmd = parts[0];
+    if (cmd === undefined) {
+      reject(new Error("Empty command string"));
+      return;
+    }
+    const args = parts.slice(1);
+
+    const ac = new AbortController();
+    let timedOut = false;
+
+    // Timeout via AbortController + setTimeout (works on Node 20.0+)
+    const timer = setTimeout(() => {
+      timedOut = true;
+      ac.abort();
+    }, timeoutMs);
+
+    // If external abort signal fires (fail-fast), abort this invocation too
+    const onExternalAbort = (): void => {
+      ac.abort();
+    };
+    if (externalSignal !== undefined) {
+      if (externalSignal.aborted) {
+        clearTimeout(timer);
+        resolve({
+          output: "",
+          duration_ms: 0,
+          exit_code: null,
+          status_code: null,
+          timed_out: false,
+          truncated: false,
+        });
+        return;
+      }
+      externalSignal.addEventListener("abort", onExternalAbort, { once: true });
+    }
+
+    const child = spawn(cmd, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      signal: ac.signal,
+    });
+
+    const chunks: Buffer[] = [];
+    let totalLength = 0;
+    let truncated = false;
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      if (totalLength < MAX_OUTPUT_LENGTH) {
+        chunks.push(chunk);
+        totalLength += chunk.length;
+        if (totalLength > MAX_OUTPUT_LENGTH) {
+          truncated = true;
+        }
+      }
+    });
+
+    // Capture stderr but don't include in output — agent output is stdout only
+    child.stderr.on("data", () => {
+      // Intentionally discarded. Stderr is not part of the eval output.
+    });
+
+    child.on("error", (err: NodeJS.ErrnoException) => {
+      clearTimeout(timer);
+      externalSignal?.removeEventListener("abort", onExternalAbort);
+      const duration_ms = Math.round(performance.now() - start);
+
+      if (err.code === "ABORT_ERR" || ac.signal.aborted) {
+        resolve({
+          output: buildOutput(chunks),
+          duration_ms,
+          exit_code: null,
+          status_code: null,
+          timed_out: timedOut,
+          truncated,
+        });
+        return;
+      }
+
+      reject(new Error(`Failed to spawn command "${command}": ${err.message}`));
+    });
+
+    child.on("close", (code: number | null) => {
+      clearTimeout(timer);
+      externalSignal?.removeEventListener("abort", onExternalAbort);
+      const duration_ms = Math.round(performance.now() - start);
+
+      if (truncated) {
+        process.stderr.write(
+          `[assay] Warning: output truncated to ${String(MAX_OUTPUT_LENGTH)} chars for command "${command}"\n`,
+        );
+      }
+
+      resolve({
+        output: buildOutput(chunks),
+        duration_ms,
+        exit_code: code,
+        status_code: null,
+        timed_out: timedOut,
+        truncated,
+      });
+    });
+
+    // Write input to stdin and close
+    if (child.stdin !== null) {
+      child.stdin.write(input);
+      child.stdin.end();
+    }
+  });
+}
+
+async function invokeHttp(
+  url: string,
+  input: string,
+  timeoutMs: number,
+  externalSignal?: AbortSignal,
+): Promise<InvokeResult> {
+  const start = performance.now();
+
+  // Combine timeout + external abort signal
+  const ac = new AbortController();
+  const timer = setTimeout(() => {
+    ac.abort();
+  }, timeoutMs);
+
+  const onExternalAbort = (): void => {
+    ac.abort();
+  };
+  if (externalSignal !== undefined) {
+    if (externalSignal.aborted) {
+      clearTimeout(timer);
+      return {
+        output: "",
+        duration_ms: 0,
+        exit_code: null,
+        status_code: null,
+        timed_out: false,
+        truncated: false,
+      };
+    }
+    externalSignal.addEventListener("abort", onExternalAbort, { once: true });
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ input }),
+      signal: ac.signal,
+      redirect: "error",
+    });
+
+    let output = await response.text();
+    let truncated = false;
+    if (output.length > MAX_OUTPUT_LENGTH) {
+      output = output.slice(0, MAX_OUTPUT_LENGTH);
+      truncated = true;
+      process.stderr.write(
+        `[assay] Warning: HTTP response truncated to ${String(MAX_OUTPUT_LENGTH)} chars from ${url}\n`,
+      );
+    }
+
+    const duration_ms = Math.round(performance.now() - start);
+    return {
+      output,
+      duration_ms,
+      exit_code: null,
+      status_code: response.status,
+      timed_out: false,
+      truncated,
+    };
+  } catch (err: unknown) {
+    const duration_ms = Math.round(performance.now() - start);
+
+    if (err instanceof DOMException && err.name === "AbortError") {
+      const timedOut = !externalSignal?.aborted;
+      return {
+        output: "",
+        duration_ms,
+        exit_code: null,
+        status_code: null,
+        timed_out: timedOut,
+        truncated: false,
+      };
+    }
+
+    throw new Error(
+      `HTTP invocation failed for ${url}: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  } finally {
+    clearTimeout(timer);
+    externalSignal?.removeEventListener("abort", onExternalAbort);
+  }
+}
+
+function buildOutput(chunks: Buffer[]): string {
+  const full = Buffer.concat(chunks).toString("utf-8");
+  if (full.length > MAX_OUTPUT_LENGTH) {
+    return full.slice(0, MAX_OUTPUT_LENGTH);
+  }
+  return full;
+}

--- a/src/report/index.ts
+++ b/src/report/index.ts
@@ -1,1 +1,77 @@
-// Proof report generation — populated in issue #14
+import type { ProofResult } from "../schema/types.js";
+
+/**
+ * Format a proof result for output.
+ *
+ * JSON is the canonical format. Markdown is a human-readable summary — full
+ * report generation is implemented in issue #14.
+ */
+export function formatReport(result: ProofResult, format: "json" | "markdown"): string {
+  if (format === "markdown") {
+    return formatMarkdown(result);
+  }
+  return JSON.stringify(result, null, 2);
+}
+
+function formatMarkdown(result: ProofResult): string {
+  const lines: string[] = [];
+
+  // Header
+  lines.push(`# Proof Result: ${result.agent_id}`);
+  lines.push("");
+  lines.push(`- **Run ID:** ${result.run_id}`);
+  lines.push(`- **Timestamp:** ${result.timestamp}`);
+  lines.push(`- **Invoke type:** ${result.run_metadata.invoke_type}`);
+  if (result.run_metadata.duration_ms !== undefined) {
+    lines.push(`- **Duration:** ${String(result.run_metadata.duration_ms)}ms`);
+  }
+  lines.push("");
+
+  // Summary
+  lines.push("## Summary");
+  lines.push("");
+  lines.push(`| Metric | Value |`);
+  lines.push(`|--------|-------|`);
+  lines.push(`| Cases run | ${String(result.cases_run)} |`);
+  lines.push(`| Passed | ${String(result.cases_passed)} |`);
+  lines.push(`| Failed | ${String(result.cases_failed)} |`);
+  lines.push(`| Confidence | ${result.confidence.score.toFixed(3)} |`);
+  lines.push(`| Variance | ${result.confidence.variance.toFixed(4)} |`);
+  lines.push(`| Maturity | ${result.confidence.maturity} |`);
+  lines.push("");
+
+  // Per-case results
+  lines.push("## Results");
+  lines.push("");
+  lines.push("| Case | Status | Output |");
+  lines.push("|------|--------|--------|");
+  for (const c of result.results) {
+    const status = c.passed ? "PASS" : "FAIL";
+    const raw = c.output.length > 80 ? c.output.slice(0, 77) + "..." : c.output;
+    const preview = raw.replaceAll("\n", " ").replaceAll("|", "\\|");
+    lines.push(`| ${c.case_id} | ${status} | ${preview} |`);
+  }
+  lines.push("");
+
+  // Known gaps
+  if (result.known_gaps.length > 0) {
+    lines.push("## Known Gaps");
+    lines.push("");
+    for (const gap of result.known_gaps) {
+      lines.push(`- ${gap}`);
+    }
+    lines.push("");
+  }
+
+  // Not checked
+  if (result.not_checked.length > 0) {
+    lines.push("## Not Checked");
+    lines.push("");
+    for (const item of result.not_checked) {
+      lines.push(`- ${item}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}

--- a/src/runner/index.test.ts
+++ b/src/runner/index.test.ts
@@ -1,0 +1,234 @@
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runEvalSuite, type RunOptions } from "./index.js";
+import type { AgentProof } from "../schema/types.js";
+import { ProofResultSchema } from "../schema/types.js";
+
+// Use echo as a simple agent — returns the input as output
+const testConfig: AgentProof = {
+  schema_version: "1",
+  agent: {
+    id: "test-agent",
+    name: "Test Agent",
+    description: "Agent for testing",
+    version: "1.0.0",
+  },
+  invoke: { type: "command", command: "cat" },
+  known_gaps: ["nothing"],
+  eval_suite: "evals",
+};
+
+let tempDir: string;
+let evalDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "assay-test-"));
+  evalDir = join(tempDir, "evals");
+  const { mkdir } = await import("node:fs/promises");
+  await mkdir(evalDir);
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function makeOptions(overrides: Partial<RunOptions> = {}): RunOptions {
+  return {
+    config: testConfig,
+    configDir: tempDir,
+    tag: undefined,
+    repeat: 1,
+    concurrency: 1,
+    failFast: false,
+    timeout: 5000,
+    dryRun: false,
+    ...overrides,
+  };
+}
+
+async function writeEvalFile(filename: string, cases: unknown[]): Promise<void> {
+  const { stringify } = await import("yaml");
+  await writeFile(join(evalDir, filename), stringify(cases));
+}
+
+const simpleCase = {
+  id: "case-1",
+  input: "hello",
+  grading: [{ type: "deterministic", check: "contains", values: ["hello"] }],
+};
+
+const secondCase = {
+  id: "case-2",
+  input: "world",
+  grading: [{ type: "deterministic", check: "contains", values: ["world"] }],
+  tags: ["greeting"],
+};
+
+describe("runEvalSuite", () => {
+  it("loads and runs eval cases from a directory", async () => {
+    await writeEvalFile("suite.yaml", [simpleCase]);
+
+    const result = await runEvalSuite(makeOptions());
+
+    expect(result.proofResult.cases_run).toBe(1);
+    expect(result.proofResult.cases_passed).toBe(1);
+    expect(result.proofResult.cases_failed).toBe(0);
+    expect(result.proofResult.results).toHaveLength(1);
+    expect(result.proofResult.results[0]).toHaveProperty("case_id", "case-1");
+    expect(result.proofResult.results[0]).toHaveProperty("passed", true);
+    expect(result.timings).toHaveLength(1);
+  });
+
+  it("resolves eval suite path relative to config directory", async () => {
+    await writeEvalFile("suite.yaml", [simpleCase]);
+
+    const result = await runEvalSuite(makeOptions());
+
+    expect(result.proofResult.cases_run).toBe(1);
+  });
+
+  it("throws when eval suite directory does not exist", async () => {
+    await expect(
+      runEvalSuite(makeOptions({ config: { ...testConfig, eval_suite: "nonexistent" } })),
+    ).rejects.toThrow("Eval suite directory not found");
+  });
+
+  it("throws when eval suite has no yaml files", async () => {
+    // evalDir exists but is empty
+    await expect(runEvalSuite(makeOptions())).rejects.toThrow("No .yaml files found");
+  });
+
+  it("throws on duplicate case IDs across files", async () => {
+    await writeEvalFile("a.yaml", [simpleCase]);
+    await writeEvalFile("b.yaml", [simpleCase]);
+
+    await expect(runEvalSuite(makeOptions())).rejects.toThrow("Duplicate case ID");
+  });
+
+  it("filters cases by tag", async () => {
+    await writeEvalFile("suite.yaml", [simpleCase, secondCase]);
+
+    const result = await runEvalSuite(makeOptions({ tag: "greeting" }));
+
+    expect(result.proofResult.cases_run).toBe(1);
+    expect(result.proofResult.results[0]).toHaveProperty("case_id", "case-2");
+  });
+
+  it("skips cases with skip: true", async () => {
+    await writeEvalFile("suite.yaml", [{ ...simpleCase, skip: true }, secondCase]);
+
+    const result = await runEvalSuite(makeOptions());
+
+    expect(result.proofResult.cases_run).toBe(1);
+    expect(result.proofResult.results[0]).toHaveProperty("case_id", "case-2");
+  });
+
+  it("returns zero cases_run for dry run", async () => {
+    await writeEvalFile("suite.yaml", [simpleCase, secondCase]);
+
+    const result = await runEvalSuite(makeOptions({ dryRun: true }));
+
+    expect(result.proofResult.cases_run).toBe(0);
+    expect(result.proofResult.cases_passed).toBe(0);
+    expect(result.proofResult.cases_failed).toBe(0);
+    expect(result.proofResult.results).toHaveLength(0);
+    expect(result.timings).toHaveLength(0);
+  });
+
+  it("produces valid ProofResult according to schema", async () => {
+    await writeEvalFile("suite.yaml", [simpleCase, secondCase]);
+
+    const result = await runEvalSuite(makeOptions());
+
+    const validation = ProofResultSchema.safeParse(result.proofResult);
+    expect(validation.success).toBe(true);
+  });
+});
+
+describe("runEvalSuite — repeat", () => {
+  it("runs each case N times with --repeat and aggregates to one result per case", async () => {
+    await writeEvalFile("suite.yaml", [simpleCase, secondCase]);
+
+    const result = await runEvalSuite(makeOptions({ repeat: 3 }));
+
+    // Results: one per unique case
+    expect(result.proofResult.results).toHaveLength(2);
+    expect(result.proofResult.cases_run).toBe(2);
+
+    // Timings: all individual invocations
+    expect(result.timings).toHaveLength(6);
+  });
+
+  it("computes zero variance when all repeats pass", async () => {
+    await writeEvalFile("suite.yaml", [simpleCase]);
+
+    const result = await runEvalSuite(makeOptions({ repeat: 3 }));
+
+    expect(result.proofResult.confidence.variance).toBe(0);
+    expect(result.proofResult.confidence.score).toBe(1);
+  });
+
+  it("includes per-repeat breakdown in grading_details when repeat > 1", async () => {
+    await writeEvalFile("suite.yaml", [simpleCase]);
+
+    const result = await runEvalSuite(makeOptions({ repeat: 2 }));
+
+    const details = result.proofResult.results[0]?.grading_details ?? [];
+    expect(details).toHaveLength(2);
+    expect(details[0]).toHaveProperty("repeat", 0);
+    expect(details[1]).toHaveProperty("repeat", 1);
+  });
+});
+
+describe("runEvalSuite — fail-fast", () => {
+  it("stops after first failure with --fail-fast", async () => {
+    // Use a command that always fails — non-zero exit doesn't cause failure
+    // since grading is stubbed to pass. Instead, mock gradeCase to fail.
+    vi.spyOn(await import("../grading/index.js"), "gradeCase").mockImplementation(
+      (evalCase, _output) => {
+        if (evalCase.id === "case-1") {
+          return [
+            {
+              layer_type: "deterministic" as const,
+              check: "contains",
+              passed: false,
+              score: 0,
+              details: "forced failure",
+            },
+          ];
+        }
+        return [
+          {
+            layer_type: "deterministic" as const,
+            check: "contains",
+            passed: true,
+            score: 1,
+            details: "pass",
+          },
+        ];
+      },
+    );
+
+    await writeEvalFile("suite.yaml", [simpleCase, secondCase]);
+
+    const result = await runEvalSuite(makeOptions({ failFast: true }));
+
+    expect(result.proofResult.cases_failed).toBeGreaterThanOrEqual(1);
+    // With fail-fast, we should have fewer total invocations than cases
+    expect(result.timings.length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("runEvalSuite — concurrency", () => {
+  it("runs cases in parallel with concurrency > 1", async () => {
+    await writeEvalFile("suite.yaml", [simpleCase, secondCase]);
+
+    const result = await runEvalSuite(makeOptions({ concurrency: 2 }));
+
+    expect(result.proofResult.cases_run).toBe(2);
+    expect(result.proofResult.cases_passed).toBe(2);
+  });
+});

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -1,0 +1,355 @@
+import { readdir, readFile } from "node:fs/promises";
+import { resolve, join } from "node:path";
+import { randomUUID } from "node:crypto";
+import type { AgentProof, EvalCase, ProofResult } from "../schema/types.js";
+import { validateEvalSuite } from "../schema/validation.js";
+import { invokeAgent } from "../invoke/index.js";
+import { gradeCase } from "../grading/index.js";
+import { computeConfidence } from "../confidence/index.js";
+
+export interface RunOptions {
+  config: AgentProof;
+  /** Working directory — eval_suite is resolved relative to this. */
+  configDir: string;
+  tag: string | undefined;
+  repeat: number;
+  concurrency: number;
+  failFast: boolean;
+  timeout: number;
+  dryRun: boolean;
+}
+
+export interface CaseTimingDetail {
+  case_id: string;
+  repeat_index: number;
+  start_time: string;
+  end_time: string;
+  duration_ms: number;
+  timed_out: boolean;
+  exit_code: number | null;
+  passed: boolean;
+}
+
+export interface RunResult {
+  proofResult: ProofResult;
+  timings: CaseTimingDetail[];
+}
+
+/** Internal type for tracking per-invocation results before aggregation. */
+interface InvocationRecord {
+  case_id: string;
+  repeat_index: number;
+  passed: boolean;
+  output: string;
+  grading_details: Record<string, unknown>[];
+  timing: CaseTimingDetail;
+}
+
+/**
+ * Load eval cases, filter, execute, grade, and aggregate into a proof result.
+ */
+export async function runEvalSuite(options: RunOptions): Promise<RunResult> {
+  const { config, configDir, tag, repeat, concurrency, failFast, timeout, dryRun } = options;
+
+  // 1. Load and validate eval cases
+  const evalSuiteDir = resolve(configDir, config.eval_suite);
+  const allCases = await loadEvalCases(evalSuiteDir);
+
+  // 2. Filter
+  const filteredCases = filterCases(allCases, tag);
+
+  // 3. Dry run
+  if (dryRun) {
+    return buildDryRunResult(config, filteredCases);
+  }
+
+  // 4. Build invocation list (cases × repeats)
+  const invocations: Array<{ evalCase: EvalCase; repeatIndex: number }> = [];
+  for (const evalCase of filteredCases) {
+    for (let r = 0; r < repeat; r++) {
+      invocations.push({ evalCase, repeatIndex: r });
+    }
+  }
+
+  // 5. Execute with concurrency limiter
+  const runStart = performance.now();
+  const ac = new AbortController();
+
+  const tasks = invocations.map(
+    ({ evalCase, repeatIndex }) =>
+      (): Promise<InvocationRecord> =>
+        executeInvocation(config, evalCase, repeatIndex, timeout, ac.signal),
+  );
+
+  const records = await runWithConcurrency(tasks, concurrency, failFast, ac);
+  const runDuration = Math.round(performance.now() - runStart);
+
+  // 6. Aggregate per case
+  const timings = records.map((r) => r.timing);
+  const proofResult = aggregateResults(config, filteredCases, records, repeat, runDuration);
+
+  return { proofResult, timings };
+}
+
+/**
+ * Load all .yaml/.yml files from the eval suite directory.
+ * Each file contains an array of EvalCase. Validates each file and checks
+ * for duplicate IDs across files.
+ */
+async function loadEvalCases(suiteDir: string): Promise<EvalCase[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(suiteDir);
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+      throw new Error(`Eval suite directory not found: ${suiteDir}`, { cause: err });
+    }
+    throw err;
+  }
+
+  const yamlFiles = entries.filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).sort();
+
+  if (yamlFiles.length === 0) {
+    throw new Error(`No .yaml files found in eval suite directory: ${suiteDir}`);
+  }
+
+  const allCases: EvalCase[] = [];
+  const seenIds = new Set<string>();
+
+  for (const file of yamlFiles) {
+    const filePath = join(suiteDir, file);
+    const content = await readFile(filePath, "utf-8");
+    const result = validateEvalSuite(content);
+
+    if (!result.success) {
+      throw new Error(`Invalid eval suite file ${file}: ${result.error.message}`);
+    }
+
+    for (const evalCase of result.data) {
+      if (seenIds.has(evalCase.id)) {
+        throw new Error(`Duplicate case ID "${evalCase.id}" found across eval suite files`);
+      }
+      seenIds.add(evalCase.id);
+      allCases.push(evalCase);
+    }
+  }
+
+  return allCases;
+}
+
+function filterCases(cases: EvalCase[], tag: string | undefined): EvalCase[] {
+  let filtered = cases.filter((c) => !c.skip);
+
+  if (tag !== undefined) {
+    filtered = filtered.filter((c) => c.tags.includes(tag));
+  }
+
+  return filtered;
+}
+
+function buildDryRunResult(config: AgentProof, cases: EvalCase[]): RunResult {
+  // Log case listing to stderr so stdout stays clean for JSON output
+  process.stderr.write(`\nDry run: ${String(cases.length)} case(s) would be executed\n\n`);
+  for (const c of cases) {
+    const tags = c.tags.length > 0 ? ` [${c.tags.join(", ")}]` : "";
+    const diff = c.difficulty !== undefined ? ` (${c.difficulty})` : "";
+    process.stderr.write(`  ${c.id}${tags}${diff}\n`);
+  }
+  process.stderr.write("\n");
+
+  const proofResult: ProofResult = {
+    schema_version: "1",
+    agent_id: config.agent.id,
+    run_id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    cases_run: 0,
+    cases_passed: 0,
+    cases_failed: 0,
+    confidence: { score: 0, maturity: "unestablished", case_count: 0, variance: 0 },
+    known_gaps: config.known_gaps,
+    not_checked: [],
+    run_metadata: { invoke_type: config.invoke.type },
+    results: [],
+  };
+
+  return { proofResult, timings: [] };
+}
+
+async function executeInvocation(
+  config: AgentProof,
+  evalCase: EvalCase,
+  repeatIndex: number,
+  timeout: number,
+  abortSignal: AbortSignal,
+): Promise<InvocationRecord> {
+  const startTime = new Date().toISOString();
+  const invokeResult = await invokeAgent(config.invoke, evalCase.input, timeout, abortSignal);
+  const endTime = new Date().toISOString();
+
+  const gradingResults = gradeCase(evalCase, invokeResult.output);
+  const passed = gradingResults.every((g) => g.passed);
+
+  const gradingDetails = gradingResults.map((g) => ({
+    layer_type: g.layer_type,
+    check: g.check,
+    passed: g.passed,
+    score: g.score,
+    details: g.details,
+    ...(g.token_usage !== undefined ? { token_usage: g.token_usage } : {}),
+  }));
+
+  return {
+    case_id: evalCase.id,
+    repeat_index: repeatIndex,
+    passed,
+    output: invokeResult.output,
+    grading_details: gradingDetails,
+    timing: {
+      case_id: evalCase.id,
+      repeat_index: repeatIndex,
+      start_time: startTime,
+      end_time: endTime,
+      duration_ms: invokeResult.duration_ms,
+      timed_out: invokeResult.timed_out,
+      exit_code: invokeResult.exit_code,
+      passed,
+    },
+  };
+}
+
+function aggregateResults(
+  config: AgentProof,
+  cases: EvalCase[],
+  records: InvocationRecord[],
+  repeat: number,
+  totalDurationMs: number,
+): ProofResult {
+  // Group records by case_id
+  const byCaseId = new Map<string, InvocationRecord[]>();
+  for (const record of records) {
+    const existing = byCaseId.get(record.case_id);
+    if (existing !== undefined) {
+      existing.push(record);
+    } else {
+      byCaseId.set(record.case_id, [record]);
+    }
+  }
+
+  const caseResults: Array<{
+    case_id: string;
+    passed: boolean;
+    output: string;
+    grading_details: Record<string, unknown>[];
+  }> = [];
+  const passRates: number[] = [];
+
+  for (const evalCase of cases) {
+    const caseRecords = byCaseId.get(evalCase.id) ?? [];
+
+    if (caseRecords.length === 0) {
+      // Case was skipped (fail-fast abort) — mark as failed
+      caseResults.push({
+        case_id: evalCase.id,
+        passed: false,
+        output: "",
+        grading_details: [],
+      });
+      passRates.push(0);
+      continue;
+    }
+
+    const passedCount = caseRecords.filter((r) => r.passed).length;
+    const allPassed = passedCount === caseRecords.length;
+    const passRate = passedCount / caseRecords.length;
+    passRates.push(passRate);
+
+    // Output: first failure's output, or last run's output if all passed
+    let output: string;
+    if (allPassed) {
+      const lastRecord = caseRecords[caseRecords.length - 1];
+      output = lastRecord?.output ?? "";
+    } else {
+      const firstFailure = caseRecords.find((r) => !r.passed);
+      output = firstFailure?.output ?? "";
+    }
+
+    // Build grading_details with per-repeat breakdown when repeat > 1
+    let gradingDetails: Record<string, unknown>[];
+    if (repeat > 1) {
+      gradingDetails = caseRecords.map((r) => ({
+        repeat: r.repeat_index,
+        passed: r.passed,
+        grading: r.grading_details,
+      }));
+    } else {
+      gradingDetails = caseRecords[0]?.grading_details ?? [];
+    }
+
+    caseResults.push({
+      case_id: evalCase.id,
+      passed: allPassed,
+      output,
+      grading_details: gradingDetails,
+    });
+  }
+
+  const casesPassed = caseResults.filter((r) => r.passed).length;
+  const casesFailed = caseResults.length - casesPassed;
+  const confidence = computeConfidence(passRates);
+
+  return {
+    schema_version: "1",
+    agent_id: config.agent.id,
+    run_id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    cases_run: caseResults.length,
+    cases_passed: casesPassed,
+    cases_failed: casesFailed,
+    confidence,
+    known_gaps: config.known_gaps,
+    not_checked: [],
+    run_metadata: {
+      invoke_type: config.invoke.type,
+      duration_ms: totalDurationMs,
+    },
+    results: caseResults,
+  };
+}
+
+/**
+ * Execute async tasks with a concurrency limit.
+ *
+ * If failFast is true and any task result has passed=false, the AbortController
+ * is signaled to abort remaining and in-flight tasks.
+ */
+async function runWithConcurrency(
+  tasks: Array<() => Promise<InvocationRecord>>,
+  limit: number,
+  failFast: boolean,
+  ac: AbortController,
+): Promise<InvocationRecord[]> {
+  const results: InvocationRecord[] = [];
+  let index = 0;
+  let aborted = false;
+
+  async function runNext(): Promise<void> {
+    while (index < tasks.length && !aborted) {
+      const currentIndex = index;
+      index++;
+      const task = tasks[currentIndex];
+      if (task === undefined) break;
+      const result = await task();
+      results.push(result);
+
+      if (failFast && !result.passed) {
+        aborted = true;
+        ac.abort();
+      }
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(limit, tasks.length) }, () => runNext());
+  await Promise.all(workers);
+
+  return results;
+}

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -64,6 +64,10 @@ const HttpInvokeSchema = z.object({
  *
  * v1 input is always a string passed via stdin (command) or request body (http).
  * Structured inputs are a known gap for future schema versions.
+ *
+ * Trust model: the invoke config is trusted — it controls what commands are
+ * spawned and what URLs are called. Users must review agent configs before
+ * running them, the same way they would review a Makefile or CI script.
  */
 export const InvokeSchema = z.discriminatedUnion("type", [CommandInvokeSchema, HttpInvokeSchema]);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2025"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,


### PR DESCRIPTION
## Summary

- Implements the core `assay eval` command — loads agent config + eval suite, invokes the agent for each test case (subprocess or HTTP), runs grading layers, and outputs a proof result
- CLI arg parsing with `util.parseArgs`: `--tag`, `--repeat`, `--format`, `--concurrency`, `--dry-run`, `--fail-fast`, `--timeout`
- Agent invocation supports command (spawn, no shell) and HTTP (fetch, redirect blocked), with timeout, output truncation detection, and abort support
- Repeat semantics: aggregates to one result per unique case, strict pass threshold (all repeats must pass), variance computed from per-case pass rates
- Stub interfaces for grading (#4-6), confidence (#7), and report (#14) with proper contracts for downstream issues
- 85 tests passing, lint clean, format clean

## Review notes

- Code review and security review were run against the diff before commit
- P1 SSRF/DNS-rebinding finding on localhost HTTP allowlist — documented as trust model (user controls config, like a Makefile)
- `--concurrency` capped at 64, `--repeat` capped at 1000 to prevent resource exhaustion
- HTTP fetch uses `redirect: "error"` to prevent silent redirects
- `InvokeResult` includes `status_code` for HTTP invocations so future grading layers can distinguish agent errors from real responses

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `npm test` — 85 tests pass
- [x] `npm run lint` — no violations
- [x] `npm run format` — all files formatted
- [x] Manual dry run: `assay eval --dry-run` lists 5 cases with tags/difficulty
- [x] Manual full run: `assay eval` with echo agent produces valid proof result JSON
- [x] Manual tag filter: `--tag security` returns 2 cases
- [x] Manual repeat: `--repeat 3 --format markdown` shows aggregated results with variance

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)